### PR TITLE
chore: Added tactic magic for unauthorized checks

### DIFF
--- a/armory/ac-04.go
+++ b/armory/ac-04.go
@@ -2,6 +2,7 @@ package armory
 
 import (
 	"fmt"
+
 	"github.com/privateerproj/privateer-sdk/raidengine"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
@@ -21,17 +22,16 @@ func AC_04() (strikeName string, result raidengine.StrikeResult) {
 }
 
 func AC_04_T01() (moveResult raidengine.MovementResult) {
-	allowed := GetData(Config).Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
-	branchName := GetData(Config).Repository.DefaultBranchRef.Name
+	allowed := GetData().Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
+	branchName := GetData().Repository.DefaultBranchRef.Name
 	msg := fmt.Sprintf("Branch Protection Prevents Deletion: %v", !allowed)
 	moveResult = raidengine.MovementResult{
 		Description: "This movement is still under construction",
-		Passed: !allowed,
-		Value: branchName,
-		Message: msg,
-		Function: utils.CallerPath(0),
+		Passed:      !allowed,
+		Value:       branchName,
+		Message:     msg,
+		Function:    utils.CallerPath(0),
 	}
-
 
 	// TODO: Use this section to write a single step or test that contributes to AC_01
 	return

--- a/armory/armory.go
+++ b/armory/armory.go
@@ -1,15 +1,16 @@
 package armory
 
 import (
+	"github.com/hashicorp/go-hclog"
 	"github.com/privateerproj/privateer-sdk/config"
 	"github.com/privateerproj/privateer-sdk/raidengine"
 )
 
 var (
-	Config *config.Config
-	Armory = raidengine.Armory{
+	GlobalConfig *config.Config
+	Logger       hclog.Logger
+	Armory       = raidengine.Armory{
 		Tactics: map[string][]raidengine.Strike{
-			"dev_unauthenticated": {}, // this will automatically be selected instead of 'dev' when a token is not provided
 			"dev": {
 				DO_01,
 				DO_02,
@@ -17,7 +18,6 @@ var (
 				DO_05,
 				DO_06,
 			},
-			"maturity_1_unauthenticated": {}, // this will automatically be selected instead of 'maturity_1' when a token is not provided
 			"maturity_1": {
 				AC_01,
 				AC_02,
@@ -34,7 +34,6 @@ var (
 				QA_01,
 				QA_02,
 			},
-			"maturity_2_unauthenticated": {}, // this will automatically be selected instead of 'maturity_2' when a token is not provided
 			"maturity_2": {
 				AC_05,
 				BR_04,
@@ -54,7 +53,6 @@ var (
 				QA_05,
 				QA_06,
 			},
-			"maturity_3_unauthenticated": {}, // this will automatically be selected instead of 'maturity_3' when a token is not provided
 			"maturity_3": {
 				AC_06,
 				DO_08,
@@ -65,3 +63,20 @@ var (
 		},
 	}
 )
+
+func SetupArmory(c *config.Config) {
+	GlobalConfig = c
+	Logger = c.Logger
+	if c.GetString("token") == "" {
+		Armory.Tactics = unauthenticatedTactics()
+	}
+}
+
+func unauthenticatedTactics() map[string][]raidengine.Strike {
+	return map[string][]raidengine.Strike{
+		"dev":        {},
+		"maturity_1": {},
+		"maturity_2": {},
+		"maturity_3": {},
+	}
+}

--- a/armory/armory.go
+++ b/armory/armory.go
@@ -9,6 +9,7 @@ var (
 	Config *config.Config
 	Armory = raidengine.Armory{
 		Tactics: map[string][]raidengine.Strike{
+			"dev_unauthenticated": {}, // this will automatically be selected instead of 'dev' when a token is not provided
 			"dev": {
 				DO_01,
 				DO_02,
@@ -16,6 +17,7 @@ var (
 				DO_05,
 				DO_06,
 			},
+			"maturity_1_unauthenticated": {}, // this will automatically be selected instead of 'maturity_1' when a token is not provided
 			"maturity_1": {
 				AC_01,
 				AC_02,
@@ -32,6 +34,7 @@ var (
 				QA_01,
 				QA_02,
 			},
+			"maturity_2_unauthenticated": {}, // this will automatically be selected instead of 'maturity_2' when a token is not provided
 			"maturity_2": {
 				AC_05,
 				BR_04,
@@ -51,6 +54,7 @@ var (
 				QA_05,
 				QA_06,
 			},
+			"maturity_3_unauthenticated": {}, // this will automatically be selected instead of 'maturity_3' when a token is not provided
 			"maturity_3": {
 				AC_06,
 				DO_08,

--- a/armory/br-06.go
+++ b/armory/br-06.go
@@ -29,7 +29,7 @@ func BR_06_T01() (moveResult raidengine.MovementResult) {
 		Function:    utils.CallerPath(0),
 	}
 
-	data := GetData(Config)
+	data := GetData()
 
 	if data.Repository.Releases.TotalCount > 0 {
 		moveResult.Value = "Releases Found"
@@ -47,7 +47,7 @@ func BR_06_T02() (moveResult raidengine.MovementResult) {
 		Function:    utils.CallerPath(0),
 	}
 
-	releaseDescription := GetData(Config).Repository.LatestRelease.Description
+	releaseDescription := GetData().Repository.LatestRelease.Description
 
 	if strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog") {
 		moveResult.Passed = true

--- a/armory/do-01.go
+++ b/armory/do-01.go
@@ -21,7 +21,7 @@ func DO_01() (strikeName string, result raidengine.StrikeResult) {
 
 // TODO
 func DO_01_T01() raidengine.MovementResult {
-	repoData := GetData(Config).Repository
+	repoData := GetData().Repository
 
 	var message string
 	if repoData.HasDiscussionsEnabled {

--- a/armory/do-02.go
+++ b/armory/do-02.go
@@ -24,7 +24,7 @@ func DO_02() (strikeName string, result raidengine.StrikeResult) {
 
 func DO_02_T01() raidengine.MovementResult {
 
-	body := GetData(Config).Repository.ContributingGuidelines.Body
+	body := GetData().Repository.ContributingGuidelines.Body
 	containsGuidelines := strings.Contains(body, "Contributing")
 
 	return raidengine.MovementResult{
@@ -33,5 +33,4 @@ func DO_02_T01() raidengine.MovementResult {
 		Passed:      containsGuidelines,
 		Message:     fmt.Sprintf("Contributing Guidelines Found: %v", containsGuidelines),
 	}
-
 }

--- a/armory/do-04.go
+++ b/armory/do-04.go
@@ -22,7 +22,7 @@ func DO_04() (strikeName string, result raidengine.StrikeResult) {
 }
 
 func DO_04_T01() raidengine.MovementResult {
-	enabled := GetData(Config).Repository.IsSecurityPolicyEnabled
+	enabled := GetData().Repository.IsSecurityPolicyEnabled
 
 	return raidengine.MovementResult{
 		Description: "Discover whether a security policy is enabled for this repo.",

--- a/armory/do-05.go
+++ b/armory/do-05.go
@@ -22,7 +22,7 @@ func DO_05() (strikeName string, result raidengine.StrikeResult) {
 }
 
 func DO_05_T01() (moveResult raidengine.MovementResult) {
-	enabled := GetData(Config).Repository.HasIssuesEnabled
+	enabled := GetData().Repository.HasIssuesEnabled
 	moveResult = raidengine.MovementResult{
 		Description: "Checking to see whether the GitHub repo has issues enabled",
 		Function:    utils.CallerPath(0),

--- a/cmd/raid.go
+++ b/cmd/raid.go
@@ -28,8 +28,6 @@ func (r *Raid) Start() (err error) {
 }
 
 func initializer(c *config.Config) (err error) {
-	armory.Config = c // for strikes to reference. TODO: not sure yet whether this mitigates the need for armory.Armory.Config
-
-	armory.GetData(c)
+	armory.SetupArmory(c)
 	return
 }


### PR DESCRIPTION
@jmeridth please tell me you can think of a better way to do this... I've gone through a few options and nothing I come back with is inherently _simple_.

Background: 

- We have chosen to use the GraphQL API, which requires authentication
- Our target user wishes to run primarily unauthenticated checks, with auth as a secondary
- We need a way to flag certain checks as auth-only

This proposal:
- Two sets of tactics are defined, with the full auth+unauth tactics list being intialized on load
- If users do not provide token, tactics will be changed to the shortlist of unauth tactics
- This way, users will not get any reporting about checks that do not apply to their situation (checking a repo they don't own)