### PR TITLE
feat: Added QA_01 + REST handling

### DIFF
--- a/armory/ac-01.go
+++ b/armory/ac-01.go
@@ -21,7 +21,7 @@ func AC_01() (string, raidengine.StrikeResult) {
 
 // TODO
 func AC_01_T01() raidengine.MovementResult {
-	required := GetData().Organization.RequiresTwoFactorAuthentication
+	required := Data.GraphQL().Organization.RequiresTwoFactorAuthentication
 
 	moveResult := raidengine.MovementResult{
 		Description: "Inspect the repo's parent to ensure that all members are required to use MFA",

--- a/armory/ac-03.go
+++ b/armory/ac-03.go
@@ -17,9 +17,9 @@ func AC_03() (string, raidengine.StrikeResult) {
 	return "AC_03", result
 }
 
-func AC_03_T01() (moveResult raidengine.MovementResult) {
-	protectionData := GetData().Repository.DefaultBranchRef.BranchProtectionRule
-  // TODO: check rulesets also
+func AC_03_T01() raidengine.MovementResult {
+	protectionData := Data.GraphQL().Repository.DefaultBranchRef.BranchProtectionRule
+	// TODO: check rulesets also
 
 	var message string
 	if protectionData.RestrictsPushes {
@@ -28,7 +28,7 @@ func AC_03_T01() (moveResult raidengine.MovementResult) {
 		message = "Branch protection rule requires approving reviews"
 	}
 
-  moveResult := raidengine.MovementResult{
+	moveResult := raidengine.MovementResult{
 		Description: "Inspect default branch for a protection rule that restricts pushes",
 		Function:    utils.CallerPath(0),
 		Passed:      protectionData.RestrictsPushes || protectionData.RequiresApprovingReviews,

--- a/armory/ac-04.go
+++ b/armory/ac-04.go
@@ -20,8 +20,8 @@ func AC_04() (string, raidengine.StrikeResult) {
 }
 
 func AC_04_T01() raidengine.MovementResult {
-	allowed := GetData().Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
-	branchName := GetData().Repository.DefaultBranchRef.Name
+	allowed := Data.GraphQL().Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
+	branchName := Data.GraphQL().Repository.DefaultBranchRef.Name
 
 	message := fmt.Sprintf("Branch Protection Prevents Deletion: %v", !allowed)
 	// TODO: check rules as well

--- a/armory/armory-graphql-data.go
+++ b/armory/armory-graphql-data.go
@@ -56,13 +56,6 @@ type GraphqlData struct {
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
-func (r *ArmoryData) GraphQL() GraphqlData {
-	if r.graphql.Repository.Name == "" {
-		r.loadGraphQLData()
-	}
-	return r.graphql
-}
-
 func (r *ArmoryData) loadGraphQLData() error {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: GlobalConfig.GetString("token")},

--- a/armory/armory-graphql-data.go
+++ b/armory/armory-graphql-data.go
@@ -8,9 +8,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var Authenticated bool
-
-type RepoData struct {
+type GraphqlData struct {
 	// Need to update token for this
 	Organization struct {
 		RequiresTwoFactorAuthentication bool
@@ -58,14 +56,14 @@ type RepoData struct {
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
-var GlobalData RepoData
-
-func GetData() RepoData {
-	if GlobalData.Repository.Name != "" {
-		return GlobalData
+func (r *ArmoryData) GraphQL() GraphqlData {
+	if r.graphql.Repository.Name == "" {
+		r.loadGraphQLData()
 	}
-	owner := GlobalConfig.GetString("owner")
-	repo := GlobalConfig.GetString("repo")
+	return r.graphql
+}
+
+func (r *ArmoryData) loadGraphQLData() error {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: GlobalConfig.GetString("token")},
 	)
@@ -74,13 +72,13 @@ func GetData() RepoData {
 	client := githubv4.NewClient(httpClient)
 
 	variables := map[string]interface{}{
-		"owner": githubv4.String(owner),
-		"name":  githubv4.String(repo),
+		"owner": githubv4.String(GlobalConfig.GetString("owner")),
+		"name":  githubv4.String(GlobalConfig.GetString("repo")),
 	}
 
-	err := client.Query(context.Background(), &GlobalData, variables)
+	err := client.Query(context.Background(), &Data.graphql, variables)
 	if err != nil {
 		Logger.Error(fmt.Sprintf("Error querying GitHub GraphQL API: %s", err.Error()))
 	}
-	return GlobalData
+	return nil
 }

--- a/armory/armory-rest-data.go
+++ b/armory/armory-rest-data.go
@@ -1,17 +1,60 @@
 package armory
 
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
 type RestData struct {
-	Id   int
-	Name string
+	owner string
+	repo  string
+	Repo  RepoData
 }
 
-func (r *ArmoryData) Rest() RestData {
-	if r.rest.Name == "" {
-		r.loadRestData()
+type RepoData struct {
+	Name    string `json:"name"`
+	Private bool   `json:"private"`
+}
+
+func (r *RestData) loadData() error {
+	r.owner = GlobalConfig.GetString("owner")
+	r.repo = GlobalConfig.GetString("repo")
+
+	if r.Repo.Name == "" {
+		r.Repo.getData(r.owner, r.repo)
 	}
-	return r.rest
+	return nil
 }
 
-func (r *ArmoryData) loadRestData() error {
-	return nil
+func (r *RepoData) getData(owner, repo string) error {
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/%s", owner, repo)
+	responseData, err := makeGetRequest(endpoint, false)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(responseData, r)
+}
+
+func makeGetRequest(endpoint string, authRequired bool) (body []byte, err error) {
+	GlobalConfig.Logger.Trace(fmt.Sprintf("GET %s", endpoint))
+	request, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if authRequired && Authenticated {
+		request.Header.Set("Authorization", "Bearer "+GlobalConfig.GetString("token"))
+	} else if authRequired && !Authenticated {
+		err = fmt.Errorf("auth required but not authenticated")
+		return nil, err
+	}
+	client := &http.Client{}
+	response, err := client.Do(request)
+
+	if err != nil {
+		err = fmt.Errorf("error making http call: %s", err.Error())
+		return nil, err
+	}
+	return io.ReadAll(response.Body)
 }

--- a/armory/armory-rest-data.go
+++ b/armory/armory-rest-data.go
@@ -1,0 +1,17 @@
+package armory
+
+type RestData struct {
+	Id   int
+	Name string
+}
+
+func (r *ArmoryData) Rest() RestData {
+	if r.rest.Name == "" {
+		r.loadRestData()
+	}
+	return r.rest
+}
+
+func (r *ArmoryData) loadRestData() error {
+	return nil
+}

--- a/armory/armory.go
+++ b/armory/armory.go
@@ -12,7 +12,7 @@ type ArmoryData struct {
 }
 
 var (
-	Authenticated bool // might not need this
+	Authenticated bool
 	GlobalConfig  *config.Config
 	Logger        hclog.Logger
 	Data          ArmoryData
@@ -25,6 +25,7 @@ var (
 				DO_05,
 				BR_06,
 				AC_01,
+				QA_01,
 			},
 			"maturity_1": {
 				AC_01,
@@ -77,14 +78,32 @@ func SetupArmory(c *config.Config) {
 	Logger = c.Logger
 	if c.GetString("token") == "" {
 		Armory.Tactics = unauthenticatedTactics()
+	} else {
+		Authenticated = true
 	}
 }
 
 func unauthenticatedTactics() map[string][]raidengine.Strike {
 	return map[string][]raidengine.Strike{
-		"dev":        {},
+		"dev": {
+			QA_01,
+		},
 		"maturity_1": {},
 		"maturity_2": {},
 		"maturity_3": {},
 	}
+}
+
+func (r *ArmoryData) Rest() RestData {
+	if r.rest.repo == "" {
+		r.rest.loadData()
+	}
+	return r.rest
+}
+
+func (r *ArmoryData) GraphQL() GraphqlData {
+	if r.graphql.Repository.Name == "" {
+		r.loadGraphQLData()
+	}
+	return r.graphql
 }

--- a/armory/armory.go
+++ b/armory/armory.go
@@ -6,10 +6,17 @@ import (
 	"github.com/privateerproj/privateer-sdk/raidengine"
 )
 
+type ArmoryData struct {
+	graphql GraphqlData
+	rest    RestData
+}
+
 var (
-	GlobalConfig *config.Config
-	Logger       hclog.Logger
-	Armory       = raidengine.Armory{
+	Authenticated bool // might not need this
+	GlobalConfig  *config.Config
+	Logger        hclog.Logger
+	Data          ArmoryData
+	Armory        = raidengine.Armory{
 		Tactics: map[string][]raidengine.Strike{
 			"dev": {
 				DO_01,

--- a/armory/br-06.go
+++ b/armory/br-06.go
@@ -24,7 +24,7 @@ func BR_06() (string, raidengine.StrikeResult) {
 }
 
 func BR_06_T01() raidengine.MovementResult {
-	releaseCount := GetData().Repository.Releases.TotalCount
+	releaseCount := Data.GraphQL().Repository.Releases.TotalCount
 
 	return raidengine.MovementResult{
 		Description: "Checking whether project has releases, passing if no releases are present",
@@ -35,7 +35,7 @@ func BR_06_T01() raidengine.MovementResult {
 }
 
 func BR_06_T02() raidengine.MovementResult {
-	releaseDescription := GetData().Repository.LatestRelease.Description
+	releaseDescription := Data.GraphQL().Repository.LatestRelease.Description
 	contains := (strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog"))
 
 	moveResult := raidengine.MovementResult{

--- a/armory/do-01.go
+++ b/armory/do-01.go
@@ -19,7 +19,7 @@ func DO_01() (string, raidengine.StrikeResult) {
 
 // TODO
 func DO_01_T01() raidengine.MovementResult {
-	repoData := GetData().Repository
+	repoData := Data.GraphQL().Repository
 
 	var message string
 	if repoData.HasDiscussionsEnabled {

--- a/armory/do-02.go
+++ b/armory/do-02.go
@@ -21,7 +21,7 @@ func DO_02() (string, raidengine.StrikeResult) {
 
 func DO_02_T01() raidengine.MovementResult {
 
-	body := GetData().Repository.ContributingGuidelines.Body
+	body := Data.GraphQL().Repository.ContributingGuidelines.Body
 	containsGuidelines := len(body) > 100
 
 	moveResult := raidengine.MovementResult{

--- a/armory/do-04.go
+++ b/armory/do-04.go
@@ -20,7 +20,7 @@ func DO_04() (string, raidengine.StrikeResult) {
 }
 
 func DO_04_T01() raidengine.MovementResult {
-	enabled := GetData().Repository.IsSecurityPolicyEnabled
+	enabled := Data.GraphQL().Repository.IsSecurityPolicyEnabled
 
 	moveResult := raidengine.MovementResult{
 		Description: "Discover whether a security policy is enabled for this repo.",

--- a/armory/do-05.go
+++ b/armory/do-05.go
@@ -20,7 +20,7 @@ func DO_05() (string, raidengine.StrikeResult) {
 }
 
 func DO_05_T01() raidengine.MovementResult {
-	enabled := GetData().Repository.HasIssuesEnabled
+	enabled := Data.GraphQL().Repository.HasIssuesEnabled
 	moveResult := raidengine.MovementResult{
 		Description: "Checking to see whether the GitHub repo has issues enabled",
 		Function:    utils.CallerPath(0),

--- a/armory/qa-01.go
+++ b/armory/qa-01.go
@@ -20,13 +20,19 @@ func QA_01() (string, raidengine.StrikeResult) {
 }
 
 func QA_01_T01() raidengine.MovementResult {
+	gotRepoData := Data.Rest().Repo.Name != ""
 	isPrivate := Data.Rest().Repo.Private
 
 	moveResult := raidengine.MovementResult{
 		Description: "Verifying that the GitHub repository is public at the target URL.",
 		Function:    utils.CallerPath(0),
-		Passed:      !isPrivate,
-		Message:     fmt.Sprintf("Public Repo: %v", !isPrivate),
+		Passed:      gotRepoData && !isPrivate,
+	}
+
+	if !gotRepoData {
+		moveResult.Message = "Repository data not found"
+	} else {
+		moveResult.Message = fmt.Sprintf("Public Repo: %t", !isPrivate)
 	}
 
 	return moveResult

--- a/armory/qa-01.go
+++ b/armory/qa-01.go
@@ -1,6 +1,8 @@
 package armory
 
 import (
+	"fmt"
+
 	"github.com/privateerproj/privateer-sdk/raidengine"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
@@ -19,11 +21,14 @@ func QA_01() (string, raidengine.StrikeResult) {
 
 // TODO
 func QA_01_T01() raidengine.MovementResult {
+	isPrivate := Data.Rest().Repo.Private
+
 	moveResult := raidengine.MovementResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
+		Passed:      !isPrivate,
+		Message:     fmt.Sprintf("Public Repo: %v", !isPrivate),
 	}
 
-	// TODO: Use this section to write a single step or test that contributes to QA_01
 	return moveResult
 }

--- a/armory/qa-01.go
+++ b/armory/qa-01.go
@@ -19,12 +19,11 @@ func QA_01() (string, raidengine.StrikeResult) {
 	return "QA_01", result
 }
 
-// TODO
 func QA_01_T01() raidengine.MovementResult {
 	isPrivate := Data.Rest().Repo.Private
 
 	moveResult := raidengine.MovementResult{
-		Description: "This movement is still under construction",
+		Description: "Verifying that the GitHub repository is public at the target URL.",
 		Function:    utils.CallerPath(0),
 		Passed:      !isPrivate,
 		Message:     fmt.Sprintf("Public Repo: %v", !isPrivate),

--- a/armory/qa-01.go
+++ b/armory/qa-01.go
@@ -7,7 +7,7 @@ import (
 
 func QA_01() (string, raidengine.StrikeResult) {
 	result := raidengine.StrikeResult{
-		Description: "The project’s source code MUST be publicly readable and have a static URL.",
+		Description: "The project's source code MUST be publicly readable and have a static URL.",
 		ControlID:   "OSPS-QA-01",
 		Movements:   make(map[string]raidengine.MovementResult),
 	}


### PR DESCRIPTION
I think we finally have a good solution for the auth/unauth handling. 

- REST data will now pull separately from GraphQL
- Each data source will only be retrieved if it's requested via Data.Rest() or Data.GraphQL()
- Added QA_01, which checks REST for `private == false`. 
- Works both authenticated or unauthenticated.

With token provided:

<img width="503" alt="Screenshot 2024-12-20 at 17 59 51" src="https://github.com/user-attachments/assets/e3fcc69e-af76-4178-bf52-2a7582610144" />

With no token provided:

<img width="494" alt="Screenshot 2024-12-20 at 18 00 11" src="https://github.com/user-attachments/assets/72692175-ca96-4dfb-9f71-b9805ac596c6" />
