### PR TITLE
chore: handle renames from sdk and core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ go-package: go-tidy go-test
 go-test:
 	@echo "  >  Validating code ..."
 	@go vet ./...
+	@go clean -testcache
 	@go test ./...
 
 go-tidy:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Privateer Raid osps-baseline
+# Privateer Plugin osps-baseline
 
 This wireframe is designed to quickly get your service pack repository up to speed!
 

--- a/armory/ac-01.go
+++ b/armory/ac-01.go
@@ -3,27 +3,27 @@ package armory
 import (
 	"fmt"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func AC_01() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func AC_01() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project's version control system MUST require multi-factor authentication for collaborators modifying the project repository settings or accessing sensitive data.",
 		ControlID:   "OSPS-AC-01",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(AC_01_T01)
+	result.ExecuteTest(AC_01_T01)
 
 	return "AC_01", result
 }
 
 // TODO
-func AC_01_T01() raidengine.MovementResult {
+func AC_01_T01() pluginkit.TestResult {
 	required := Data.GraphQL().Organization.RequiresTwoFactorAuthentication
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Inspect the repo's parent to ensure that all members are required to use MFA",
 		Function:    utils.CallerPath(0),
 		Passed:      required,

--- a/armory/ac-02.go
+++ b/armory/ac-02.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func AC_02() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func AC_02() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project’s version control system MUST restrict collaborator permissions to the lowest available privileges by default.",
 		ControlID:   "OSPS-AC-02",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(AC_02_T01)
+	result.ExecuteTest(AC_02_T01)
 
 	return "AC_02", result
 }
 
-func AC_02_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func AC_02_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/ac-03.go
+++ b/armory/ac-03.go
@@ -1,23 +1,23 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func AC_03() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func AC_03() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project's version control system MUST prevent unintentional direct commits against the primary branch.",
 		ControlID:   "OSPS-AC-03",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(AC_03_T01)
+	result.ExecuteTest(AC_03_T01)
 
 	return "AC_03", result
 }
 
-func AC_03_T01() raidengine.MovementResult {
+func AC_03_T01() pluginkit.TestResult {
 	protectionData := Data.GraphQL().Repository.DefaultBranchRef.BranchProtectionRule
 	// TODO: check rulesets also
 
@@ -28,7 +28,7 @@ func AC_03_T01() raidengine.MovementResult {
 		message = "Branch protection rule requires approving reviews"
 	}
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Inspect default branch for a protection rule that restricts pushes",
 		Function:    utils.CallerPath(0),
 		Passed:      protectionData.RestrictsPushes || protectionData.RequiresApprovingReviews,

--- a/armory/ac-04.go
+++ b/armory/ac-04.go
@@ -3,30 +3,30 @@ package armory
 import (
 	"fmt"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func AC_04() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func AC_04() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project’s version control system MUST prevent unintentional deletion of the primary branch.",
 		ControlID:   "OSPS-AC-04",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(AC_04_T01)
+	result.ExecuteTest(AC_04_T01)
 
 	return "AC_04", result
 }
 
-func AC_04_T01() raidengine.MovementResult {
+func AC_04_T01() pluginkit.TestResult {
 	allowed := Data.GraphQL().Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
 	branchName := Data.GraphQL().Repository.DefaultBranchRef.Name
 
 	message := fmt.Sprintf("Branch Protection Prevents Deletion: %v", !allowed)
 	// TODO: check rules as well
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Passed:      !allowed,
 		Value:       fmt.Sprintf("Branch name: %s", branchName),

--- a/armory/ac-05.go
+++ b/armory/ac-05.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func AC_05() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func AC_05() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project’s permissions in CI/CD pipelines MUST be configured to the lowest available privileges except when explicitly elevated.",
 		ControlID:   "OSPS-AC-05",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(AC_05_T01)
+	result.ExecuteTest(AC_05_T01)
 
 	return "AC_05", result
 }
 
-func AC_05_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func AC_05_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/ac-06.go
+++ b/armory/ac-06.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func AC_06() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func AC_06() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project’s version control system MUST require multi-factor authentication that does not include SMS for users when modifying the project repository settings or accessing sensitive data.",
 		ControlID:   "OSPS-AC-06",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(AC_06_T01)
+	result.ExecuteTest(AC_06_T01)
 
 	return "AC_06", result
 }
 
-func AC_06_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func AC_06_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/armory.go
+++ b/armory/armory.go
@@ -3,7 +3,7 @@ package armory
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 )
 
 type ArmoryData struct {
@@ -16,8 +16,8 @@ var (
 	GlobalConfig  *config.Config
 	Logger        hclog.Logger
 	Data          ArmoryData
-	Armory        = raidengine.Armory{
-		Tactics: map[string][]raidengine.Strike{
+	Armory        = pluginkit.Armory{
+		TestSuites: map[string][]pluginkit.TestSet{
 			"dev": {
 				DO_01,
 				DO_02,
@@ -79,14 +79,14 @@ func SetupArmory(c *config.Config) {
 	GlobalConfig = c
 	Logger = c.Logger
 	if c.GetString("token") == "" {
-		Armory.Tactics = unauthenticatedTactics()
+		Armory.TestSuites = unauthenticatedTestSuites()
 	} else {
 		Authenticated = true
 	}
 }
 
-func unauthenticatedTactics() map[string][]raidengine.Strike {
-	return map[string][]raidengine.Strike{
+func unauthenticatedTestSuites() map[string][]pluginkit.TestSet {
+	return map[string][]pluginkit.TestSet{
 		"dev": {
 			QA_01,
 			BR_02,

--- a/armory/br-01.go
+++ b/armory/br-01.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_01() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_01() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project’s build and release pipelines MUST NOT execute arbitrary code that is input from outside of the build script.",
 		ControlID:   "OSPS-BR-01",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_01_T01)
+	result.ExecuteTest(BR_01_T01)
 
 	return "BR_01", result
 }
 
 // TODO
-func BR_01_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func BR_01_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/br-02.go
+++ b/armory/br-02.go
@@ -4,28 +4,28 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_02() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_02() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All releases and released software assets MUST be assigned a unique version identifier for each release intended to be used by users.",
 		ControlID:   "OSPS-BR-02",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_02_T01)
-	if !strings.Contains(result.Movements["BR_02_T01"].Message, ": 0") {
-		result.ExecuteMovement(BR_02_T02)
+	result.ExecuteTest(BR_02_T01)
+	if !strings.Contains(result.Tests["BR_02_T01"].Message, ": 0") {
+		result.ExecuteTest(BR_02_T02)
 	}
 	return "BR_02", result
 }
 
-func BR_02_T01() raidengine.MovementResult {
+func BR_02_T01() pluginkit.TestResult {
 	releases := Data.Rest().Repo.Releases
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Discover all releases on the repository",
 		Function:    utils.CallerPath(0),
 		Passed:      true,
@@ -37,7 +37,7 @@ func BR_02_T01() raidengine.MovementResult {
 	return moveResult
 }
 
-func BR_02_T02() raidengine.MovementResult {
+func BR_02_T02() pluginkit.TestResult {
 	releases := Data.Rest().Repo.Releases
 
 	releaseNames := make(map[string]int)
@@ -55,7 +55,7 @@ func BR_02_T02() raidengine.MovementResult {
 		}
 	}
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Ensure all releases have a unique name",
 		Function:    utils.CallerPath(0),
 		Passed:      errorCount == 0,

--- a/armory/br-03.go
+++ b/armory/br-03.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_03() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_03() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "Any websites, API responses or other services involved in the project development and release MUST be delivered using SSH, HTTPS or other encrypted channels.",
 		ControlID:   "OSPS-BR-03",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_03_T01)
+	result.ExecuteTest(BR_03_T01)
 
 	return "BR_03", result
 }
 
-func BR_03_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func BR_03_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/br-04.go
+++ b/armory/br-04.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_04() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_04() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All released software assets MUST be created with consistent, automated build and release pipelines.",
 		ControlID:   "OSPS-BR-04",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_04_T01)
+	result.ExecuteTest(BR_04_T01)
 
 	return "BR_04", result
 }
 
-func BR_04_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func BR_04_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/br-05.go
+++ b/armory/br-05.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_05() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_05() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All build and release pipelines MUST use standardized tooling where available to ingest dependencies at build time.",
 		ControlID:   "OSPS-BR-05",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_05_T01)
+	result.ExecuteTest(BR_05_T01)
 
 	return "BR_05", result
 }
 
-func BR_05_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func BR_05_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/br-06.go
+++ b/armory/br-06.go
@@ -4,29 +4,29 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_06() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_06() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All releases MUST provide a descriptive log of functional and security modifications.",
 		ControlID:   "OSPS-BR-06",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_06_T01)
-	if !strings.Contains(result.Movements["BR_06_T01"].Message, ": 0") {
+	result.ExecuteTest(BR_06_T01)
+	if !strings.Contains(result.Tests["BR_06_T01"].Message, ": 0") {
 		Logger.Trace("Releases Found, checking for Change Log")
-		result.ExecuteMovement(BR_06_T02)
+		result.ExecuteTest(BR_06_T02)
 	}
 	return "BR_06", result
 }
 
-func BR_06_T01() raidengine.MovementResult {
+func BR_06_T01() pluginkit.TestResult {
 	releaseCount := Data.GraphQL().Repository.Releases.TotalCount
 
-	return raidengine.MovementResult{
+	return pluginkit.TestResult{
 		Description: "Checking whether project has releases, passing if no releases are present",
 		Function:    utils.CallerPath(0),
 		Passed:      true,
@@ -34,11 +34,11 @@ func BR_06_T01() raidengine.MovementResult {
 	}
 }
 
-func BR_06_T02() raidengine.MovementResult {
+func BR_06_T02() pluginkit.TestResult {
 	releaseDescription := Data.GraphQL().Repository.LatestRelease.Description
 	contains := (strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog"))
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Checking whether project has releases, passing if no releases are present",
 		Function:    utils.CallerPath(0),
 		Passed:      contains,

--- a/armory/br-07.go
+++ b/armory/br-07.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func BR_07() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func BR_07() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All released software assets MUST be signed or accounted for in a signed manifest including each asset’s cryptographic hashes.",
 		ControlID:   "OSPS-BR-07",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(BR_07_T01)
+	result.ExecuteTest(BR_07_T01)
 
 	return "BR_07", result
 }
 
-func BR_07_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func BR_07_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-01.go
+++ b/armory/do-01.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_01() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_01() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project MUST have one or more mechanisms for public discussions about proposed changes and usage obstacles.",
 		ControlID:   "OSPS-DO-01",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_01_T01)
+	result.ExecuteTest(DO_01_T01)
 
 	return "DO_01", result
 }
 
 // TODO
-func DO_01_T01() raidengine.MovementResult {
+func DO_01_T01() pluginkit.TestResult {
 	repoData := Data.GraphQL().Repository
 
 	var message string
@@ -29,7 +29,7 @@ func DO_01_T01() raidengine.MovementResult {
 		message = message + "Issues are enabled."
 	}
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Discover whether issues or discussions are enabled on the repo.",
 		Function:    utils.CallerPath(0),
 		Message:     message,

--- a/armory/do-02.go
+++ b/armory/do-02.go
@@ -3,28 +3,28 @@ package armory
 import (
 	"fmt"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_02() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_02() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include an explanation of the contribution process.",
 		ControlID:   "OSPS-DO-02",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_02_T01)
+	result.ExecuteTest(DO_02_T01)
 
 	return "DO_02", result
 }
 
-func DO_02_T01() raidengine.MovementResult {
+func DO_02_T01() pluginkit.TestResult {
 
 	body := Data.GraphQL().Repository.ContributingGuidelines.Body
 	containsGuidelines := len(body) > 100
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Discover whether the GitHub repo's recommended contributing guidelines has content.",
 		Function:    utils.CallerPath(0),
 		Passed:      containsGuidelines,

--- a/armory/do-03.go
+++ b/armory/do-03.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_03() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_03() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST provide user guides for all basic functionality.",
 		ControlID:   "OSPS-DO-03",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_03_T01)
+	result.ExecuteTest(DO_03_T01)
 
 	return "DO_03", result
 }
 
-func DO_03_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_03_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-04.go
+++ b/armory/do-04.go
@@ -3,26 +3,26 @@ package armory
 import (
 	"fmt"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_04() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_04() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include a policy for coordinated vulnerability reporting, with a clear timeframe for response.",
 		ControlID:   "OSPS-DO-04",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_04_T01)
+	result.ExecuteTest(DO_04_T01)
 
 	return "DO_04", result
 }
 
-func DO_04_T01() raidengine.MovementResult {
+func DO_04_T01() pluginkit.TestResult {
 	enabled := Data.GraphQL().Repository.IsSecurityPolicyEnabled
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Discover whether a security policy is enabled for this repo.",
 		Function:    utils.CallerPath(0),
 		Passed:      enabled,

--- a/armory/do-05.go
+++ b/armory/do-05.go
@@ -3,25 +3,25 @@ package armory
 import (
 	"fmt"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_05() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_05() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include a mechanism for reporting defects.",
 		ControlID:   "OSPS-DO-05",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_05_T01)
+	result.ExecuteTest(DO_05_T01)
 
 	return "DO_05", result
 }
 
-func DO_05_T01() raidengine.MovementResult {
+func DO_05_T01() pluginkit.TestResult {
 	enabled := Data.GraphQL().Repository.HasIssuesEnabled
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Checking to see whether the GitHub repo has issues enabled",
 		Function:    utils.CallerPath(0),
 		Passed:      enabled,

--- a/armory/do-06.go
+++ b/armory/do-06.go
@@ -1,23 +1,23 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_06() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_06() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include a guide for code contributors that includes requirements for acceptable contributions.",
 		ControlID:   "OSPS-DO-06",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_06_T01)
+	result.ExecuteTest(DO_06_T01)
 	return "DO_06", result
 }
 
-func DO_06_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_06_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-07.go
+++ b/armory/do-07.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_07() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_07() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST provide design documentation demonstrating all actions and actors within the system.",
 		ControlID:   "OSPS-AC-01",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_07_T01)
+	result.ExecuteTest(DO_07_T01)
 
 	return "DO_07", result
 }
 
 // TODO
-func DO_07_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_07_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-08.go
+++ b/armory/do-08.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_08() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_08() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include a policy that defines a threshold for remediation of SCA findings related to vulnerabilities and licenses.",
 		ControlID:   "OSPS-DO-08",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_08_T01)
+	result.ExecuteTest(DO_08_T01)
 
 	return "DO_08", result
 }
 
 // TODO
-func DO_08_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_08_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-09.go
+++ b/armory/do-09.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_09() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_09() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include descriptions of all external input and output interfaces of the released software assets.",
 		ControlID:   "OSPS-DO-09",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_09_T01)
+	result.ExecuteTest(DO_09_T01)
 
 	return "DO_09", result
 }
 
 // TODO
-func DO_09_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_09_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-10.go
+++ b/armory/do-10.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_10() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_10() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST include a policy to address SCA violations prior to any release.",
 		ControlID:   "OSPS-DO-10",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_10_T01)
+	result.ExecuteTest(DO_10_T01)
 
 	return "DO_10", result
 }
 
 // TODO
-func DO_10_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_10_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-11.go
+++ b/armory/do-11.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_11() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_11() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST have a policy that code contributors are reviewed prior to granting escalated permissions to sensitive resources.",
 		ControlID:   "OSPS-DO-11",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_11_T01)
+	result.ExecuteTest(DO_11_T01)
 
 	return "DO_11", result
 }
 
 // TODO
-func DO_11_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_11_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/do-12.go
+++ b/armory/do-12.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func DO_12() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func DO_12() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project documentation MUST contain instructions to verify the integrity and authenticity of the release assets, including the expected identity of the person or process authoring the software release.",
 		ControlID:   "OSPS-DO-12",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(DO_12_T01)
+	result.ExecuteTest(DO_12_T01)
 
 	return "DO_12", result
 }
 
 // TODO
-func DO_12_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func DO_12_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/le-01.go
+++ b/armory/le-01.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func LE_01() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func LE_01() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The version control system MUST require all code contributors to assert that they are legally authorized to commit the associated contributions on every commit.",
 		ControlID:   "OSPS-LE-01",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(LE_01_T01)
+	result.ExecuteTest(LE_01_T01)
 
 	return "LE_01", result
 }
 
 // TODO
-func LE_01_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func LE_01_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/le-02.go
+++ b/armory/le-02.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func LE_02() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func LE_02() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The license for the source code MUST meet the OSI Open Source Definition or the FSF Free Software Definition.",
 		ControlID:   "OSPS-LE-02",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(LE_02_T01)
+	result.ExecuteTest(LE_02_T01)
 
 	return "LE_02", result
 }
 
 // TODO
-func LE_02_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func LE_02_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/le-03.go
+++ b/armory/le-03.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func LE_03() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func LE_03() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The license for the source code MUST be maintained in a standard location within the project’s repository.",
 		ControlID:   "OSPS-LE-03",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(LE_03_T01)
+	result.ExecuteTest(LE_03_T01)
 
 	return "LE_03", result
 }
 
 // TODO
-func LE_03_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func LE_03_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/le-04.go
+++ b/armory/le-04.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func LE_04() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func LE_04() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition.",
 		ControlID:   "OSPS-LE-04",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(LE_04_T01)
+	result.ExecuteTest(LE_04_T01)
 
 	return "LE_04", result
 }
 
 // TODO
-func LE_04_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func LE_04_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/qa-01.go
+++ b/armory/qa-01.go
@@ -3,27 +3,27 @@ package armory
 import (
 	"fmt"
 
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_01() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_01() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The project's source code MUST be publicly readable and have a static URL.",
 		ControlID:   "OSPS-QA-01",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_01_T01)
+	result.ExecuteTest(QA_01_T01)
 
 	return "QA_01", result
 }
 
-func QA_01_T01() raidengine.MovementResult {
+func QA_01_T01() pluginkit.TestResult {
 	gotRepoData := Data.Rest().Repo.Name != ""
 	isPrivate := Data.Rest().Repo.Private
 
-	moveResult := raidengine.MovementResult{
+	moveResult := pluginkit.TestResult{
 		Description: "Verifying that the GitHub repository is public at the target URL.",
 		Function:    utils.CallerPath(0),
 		Passed:      gotRepoData && !isPrivate,

--- a/armory/qa-02.go
+++ b/armory/qa-02.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_02() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_02() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The version control system MUST contain a publicly readable record of all changes made, who made the changes, and when the changes were made.",
 		ControlID:   "OSPS-QA-02",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_02_T01)
+	result.ExecuteTest(QA_02_T01)
 
 	return "QA_02", result
 }
 
 // TODO
-func QA_02_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func QA_02_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/qa-03.go
+++ b/armory/qa-03.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_03() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_03() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All released software assets MUST be delivered with a machine-readable list of all direct and transitive internal software dependencies with their associated version identifiers.",
 		ControlID:   "OSPS-QA-03",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_03_T01)
+	result.ExecuteTest(QA_03_T01)
 
 	return "QA_03", result
 }
 
 // TODO
-func QA_03_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func QA_03_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/qa-04.go
+++ b/armory/qa-04.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_04() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_04() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "Any automated status checks for commits MUST pass or require manual acknowledgement prior to merge.",
 		ControlID:   "OSPS-QA-04",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_04_T01)
+	result.ExecuteTest(QA_04_T01)
 
 	return "QA_04", result
 }
 
-func QA_04_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func QA_04_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/qa-05.go
+++ b/armory/qa-05.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_05() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_05() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "Any additional subproject code repositories produced by the project and compiled into a release MUST enforce security requirements as applicable to the status and intent of the respective codebase.",
 		ControlID:   "OSPS-QA-05",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_05_T01)
+	result.ExecuteTest(QA_05_T01)
 
 	return "QA_05", result
 }
 
-func QA_05_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func QA_05_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/qa-06.go
+++ b/armory/qa-06.go
@@ -1,24 +1,24 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_06() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_06() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "The version control system MUST NOT contain generated executable artifacts.",
 		ControlID:   "OSPS-QA-06",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_06_T01)
+	result.ExecuteTest(QA_06_T01)
 
 	return "QA_06", result
 }
 
-func QA_06_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func QA_06_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/armory/qa-07.go
+++ b/armory/qa-07.go
@@ -1,25 +1,25 @@
 package armory
 
 import (
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/privateerproj/privateer-sdk/utils"
 )
 
-func QA_07() (string, raidengine.StrikeResult) {
-	result := raidengine.StrikeResult{
+func QA_07() (string, pluginkit.TestSetResult) {
+	result := pluginkit.TestSetResult{
 		Description: "All proposed changes to the project’s codebase must be automatically evaluated against a documented policy for known vulnerabilities and blocked in the event of violations except when declared and supressed as non exploitable.",
 		ControlID:   "OSPS-QA-07",
-		Movements:   make(map[string]raidengine.MovementResult),
+		Tests:       make(map[string]pluginkit.TestResult),
 	}
 
-	result.ExecuteMovement(QA_07_T01)
+	result.ExecuteTest(QA_07_T01)
 
 	return "QA_07", result
 }
 
 // TODO
-func QA_07_T01() raidengine.MovementResult {
-	moveResult := raidengine.MovementResult{
+func QA_07_T01() pluginkit.TestResult {
+	moveResult := pluginkit.TestResult{
 		Description: "This movement is still under construction",
 		Function:    utils.CallerPath(0),
 	}

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -10,7 +10,7 @@ var (
 	// debugCmd represents the base command when called without any subcommands
 	debugCmd = &cobra.Command{
 		Use:   "debug",
-		Short: "Run the Raid in debug mode",
+		Short: "Run the Plugin in debug mode",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := Vessel.Mobilize()
 			if err != nil {
@@ -21,5 +21,5 @@ var (
 )
 
 func init() {
-	runCmd.AddCommand(debugCmd) // This enables the debug command for use while working on your Raid
+	runCmd.AddCommand(debugCmd) // This enables the debug command for use while working on your Plugin
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -4,25 +4,25 @@ import (
 	"github.com/eddie-knight/raid-osps-baseline/armory"
 
 	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/privateerproj/privateer-sdk/raidengine"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 )
 
 var (
-	Vessel = raidengine.Vessel{
-		RaidName:    "osps-baseline",
+	Vessel = pluginkit.Vessel{
+		PluginName:  "osps-baseline",
 		Armory:      &armory.Armory,
 		Initializer: initializer,
 		RequiredVars: []string{
 			"owner",
 			"repo",
 		},
-	} // Used by the plugin or debug function to run the Raid
+	} // Used by the plugin or debug function to run the Plugin
 )
 
-type Raid struct{}
+type Plugin struct{}
 
-// Raid.Start() is called by plugin.Serve
-func (r *Raid) Start() (err error) {
+// Plugin.Start() is called by plugin.Serve
+func (p *Plugin) Start() (err error) {
 	err = Vessel.Mobilize()
 	return
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/privateerproj/privateer-sdk/command"
-	"github.com/privateerproj/privateer-sdk/plugin"
+	"github.com/privateerproj/privateer-sdk/shared"
 )
 
 var (
@@ -16,23 +16,23 @@ var (
 	buildGitCommitHash string
 	buildTime          string
 
-	RaidName = "osps-baseline"
+	PluginName = "osps-baseline"
 
 	// runCmd represents the base command when called without any subcommands
 	runCmd = &cobra.Command{
-		Use:   RaidName,
-		Short: fmt.Sprintf("Test suite for %s.", RaidName),
+		Use:   PluginName,
+		Short: fmt.Sprintf("Test suite for %s.", PluginName),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// optional
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			// Serve plugin
-			raid := &Raid{}
-			serveOpts := &plugin.ServeOpts{
-				Plugin: raid,
+			plugin := &Plugin{}
+			serveOpts := &shared.ServeOpts{
+				Plugin: plugin,
 			}
 
-			plugin.Serve(RaidName, serveOpts)
+			shared.Serve(PluginName, serveOpts)
 		},
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,19 @@ module github.com/eddie-knight/raid-osps-baseline // Replace this globally with 
 go 1.23
 
 require (
-	github.com/privateerproj/privateer-sdk v0.0.16
+	github.com/hashicorp/go-hclog v1.6.3
+	github.com/privateerproj/privateer-sdk v0.0.17
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	golang.org/x/oauth2 v0.18.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
@@ -44,8 +45,7 @@ require (
 	google.golang.org/grpc v1.62.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // Uncomment if you're working locally on a privateer SDK improvement
-replace github.com/privateerproj/privateer-sdk => ../privateer-sdk
+// replace github.com/privateerproj/privateer-sdk => ../privateer-sdk

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/privateerproj/privateer-sdk v0.0.17 h1:buTquGwlM3+lLggiaWUsOOxlPpNaYOYFv3R39HWN2ss=
+github.com/privateerproj/privateer-sdk v0.0.17/go.mod h1:XC29QRTD3NqSVDby1wIVcd3rer5lFFn9I/8Px0xPsrs=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Renames happened in:

- https://github.com/privateerproj/privateer-sdk/pull/39
- https://github.com/privateerproj/privateer-sdk/pull/40
- https://github.com/privateerproj/privateer/pull/50

We probably want to rename the repository and then update more stuff (README, etc)